### PR TITLE
fix: Update broken MDN link to new URL structure

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,5 +1,5 @@
 This extension does not store any personally identifiable information.
-This extension uses your browser's  [browser.storage.sync](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage/sync)
+This extension uses your browser's  [browser.storage.sync](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync)
 to sync your data across devices. This data only consists of 
 your custom right-click menu and its settings.
 This means that these settings are stored on your browser manufacturer's servers.


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates broken MDN URLs from the old format to the new format.